### PR TITLE
Add note that will save people trouble with Safari.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,8 @@ seconds.
 
 > **Note:** When using custom headers, like `X-Auth-Token` or `X-Requested-With`, you must set the allowedHeaders to include those headers. You can also set it to `array('*')` to allow all custom headers.
 
+> **Note:** If you are explicitly whitelisting headers, you must include `Origin` or requests will fail to be recognized as CORS.
+
     'defaults' => array(
         'supportsCredentials' => false,
         'allowedOrigins' => array(),


### PR DESCRIPTION
If you do not add Origin in allowedHeaders, the isCorsRequest method in the CorsService class will fail.