### PR TITLE
Update HandlePreflight to avoid returning wrong status code

### DIFF
--- a/src/HandlePreflight.php
+++ b/src/HandlePreflight.php
@@ -22,13 +22,10 @@ class HandlePreflight
 	 */
 	public function handle($request, Closure $next)
 	{
-		$response = $next($request);
-
 		if ($this->cors->isPreflightRequest($request)) {
-			$preflight = $this->cors->handlePreflightRequest($request);
-			$response->headers->add($preflight->headers->all());
+			return $this->cors->handlePreflightRequest($request);
 		}
 
-		return $response;
+		return $next($request);
 	}
 }


### PR DESCRIPTION
HandlePreflight will fail for some routes, for instance this one:

``` php
Route::post('upload', 'UploadController@handle');
```

In a preflight (`OPTIONS`) request, it is really not needed to depend on a route or controller existence.
