### PR TITLE
Only return proper CORS preflight headers if the OPTIONS request matches a route that's CORS-enabled

### DIFF
--- a/src/HandlePreflight.php
+++ b/src/HandlePreflight.php
@@ -2,15 +2,17 @@
 
 use Closure;
 use Asm89\Stack\CorsService;
+use Illuminate\Routing\Router;
 
 class HandlePreflight
 {
 	/**
 	 * @param CorsService $cors
 	 */
-	public function __construct(CorsService $cors)
+	public function __construct(CorsService $cors, Router $router)
 	{
 		$this->cors = $cors;
+		$this->router = $router;
 	}
 
 	/**
@@ -24,11 +26,23 @@ class HandlePreflight
 	{
 		$response = $next($request);
 
-		if ($this->cors->isPreflightRequest($request)) {
+		if ($this->cors->isPreflightRequest($request) && $this->hasMatchingCorsRoute($request)) {
 			$preflight = $this->cors->handlePreflightRequest($request);
 			$response->headers->add($preflight->headers->all());
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Verify the current OPTIONS request matches a CORS-enabled route
+	 * @param  \Illuminate\Http\Request  $request
+	 * @return boolean
+	 */
+	private function hasMatchingCorsRoute($request)
+	{
+		$request = clone $request;
+		$request->setMethod($request->header('Access-Control-Request-Method'));
+		return in_array('cors', $this->router->getRoutes()->match($request)->middleware());
 	}
 }


### PR DESCRIPTION
Resolves #91 for me locally, pull it down and give it a go :+1: 

`RouteCollection::match` will automatically throw a 404 if it matches no routes, so it doesn't need to be handled explicitly which is nice.