### PR TITLE
Default allowedMethods to "*"

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -7,14 +7,14 @@ return [
      |--------------------------------------------------------------------------
      |
 
-     | allowedOrigins, allowedHeaders and allowedMethods can be set to array('*') 
-     | to accept any value, the allowed methods however have to be explicitly listed.
+     | allowedOrigins, allowedHeaders and allowedMethods can be set to array('*')
+     | to accept any value.
      |
      */
     'supportsCredentials' => false,
     'allowedOrigins' => ['*'],
     'allowedHeaders' => ['*'],
-    'allowedMethods' => ['GET', 'POST', 'PUT',  'DELETE'],
+    'allowedMethods' => ['*'],
     'exposedHeaders' => [],
     'maxAge' => 0,
     'hosts' => [],


### PR DESCRIPTION
Currently, if you provide a list of allowed methods, all of those methods are _always_ returned as allowed in response to the preflight request.

This means that if you had a DELETE route and POST route with the same endpoint, but you only wanted the POST route to support CORS, the preflight request would come back and say that DELETE was supported as well, even though it is not.

`*` on the other hand only includes the requested method in the response, as you can see here:

https://github.com/asm89/stack-cors/blob/master/src/Asm89/Stack/CorsService.php#L114-L117

This in combination with #92 means if you had a setup like this:

```
Route::delete('my-route', 'Controller@action');

Route::group(['middleware' => ['cors']], function () {
    Route::post('my-route', 'Controller@action');
});
```

...a preflight request for the DELETE endpoint would disallow CORS entirely, and a preflight request for the POST endpoint would set the `Access-Control-Allow-Methods` header to just `POST`, rather than `GET, POST, PUT, DELETE` like the current default would.

Overall using "*" as the default setting actually tightens up the CORS restrictions and allows things to behave in a more automatic way, so you don't even have to worry about configuring which methods are allowed and in conjuction with #92, it will all be done automatically based on the routes you've added the `cors` middleware to.