### PR TITLE
add: support for defining origins by regExp

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -13,6 +13,7 @@ return [
      */
     'supportsCredentials' => false,
     'allowedOrigins' => ['*'],
+    'allowedOriginsRegExp' => [],
     'allowedHeaders' => ['*'],
     'allowedMethods' => ['*'],
     'exposedHeaders' => [],

--- a/src/Stack/CorsService.php
+++ b/src/Stack/CorsService.php
@@ -23,6 +23,7 @@ class CorsService
 
         $options += array(
             'allowedOrigins' => array(),
+            'allowedOriginsRegExp' => array(),
             'supportsCredentials' => false,
             'allowedHeaders' => array(),
             'exposedHeaders' => array(),
@@ -165,7 +166,16 @@ class CorsService
         }
         $origin = $request->headers->get('Origin');
 
-        return in_array($origin, $this->options['allowedOrigins']);
+        if (in_array($origin, $this->options['allowedOrigins'])) {
+            return true;
+        } else {
+            foreach ($this->options['allowedOriginsRegExp'] as $regExp) {
+                if (preg_match($regExp, $origin)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private function checkMethod(Request $request) {

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -39,7 +39,7 @@ class CorsTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($unmodifiedResponse->headers, $response->headers);
     }
-    
+
     /**
      * @test
      */
@@ -59,6 +59,33 @@ class CorsTest extends PHPUnit_Framework_TestCase
     public function it_returns_allow_origin_header_on_valid_actual_request()
     {
         $app      = $this->createStackedApp();
+        $request  = $this->createValidActualRequest();
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($response->headers->has('Access-Control-Allow-Origin'));
+        $this->assertEquals('localhost', $response->headers->get('Access-Control-Allow-Origin'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_403_on_valid_actual_request_with_origin_regExp_not_allowed()
+    {
+        $app      = $this->createStackedApp(array('allowedOrigins' => array(''), 'allowedOriginsRegExp' => array('/notlocal.ost/i')));
+        $request  = $this->createValidActualRequest();
+
+        $response = $app->handle($request);
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_allow_origin_header_on_valid_regExp_actual_request()
+    {
+        $app      = $this->createStackedApp(array('allowedOrigins' => array(''), 'allowedOriginsRegExp' => array('/local.ost/i')));
         $request  = $this->createValidActualRequest();
 
         $response = $app->handle($request);


### PR DESCRIPTION
Hi there

for our dev environment different branches are represented by different subdomains, so it is useful to define the define allowed origin using some sort of wildcard.

This implements the feature using regular expressions, as well as covers it with tests.

If you could merge this feature into your project, that would be awesome

Thank you very much

Marian
