### PR TITLE
Fix middleware checking in preflight handler

### DIFF
--- a/src/HandlePreflight.php
+++ b/src/HandlePreflight.php
@@ -54,8 +54,10 @@ class HandlePreflight
 		$request->setMethod($request->header('Access-Control-Request-Method'));
 
 		try {
-			$middleware = $this->router->getRoutes()->match($request)->middleware();
-			return in_array('cors', $middleware);
+			$route = $this->router->getRoutes()->match($request);
+			$middleware = $this->router->gatherRouteMiddlewares($route);
+
+			return in_array(HandleCors::class, $middleware);
 		} catch (\Exception $e){
 			return false;
 		}


### PR DESCRIPTION
Hi, this is a quick fix for better handling `cors` middleware when defined in a middleware group. This PR addresses #113, #112, #110.

PhpUnit tests run smoothly, and I tested manually with:
- Laravel 5.1/5.2;
- Lumen 5.1/5.2.