### PR TITLE
Support wildcard and port range for allowed origins

### DIFF
--- a/src/Stack/CorsService.php
+++ b/src/Stack/CorsService.php
@@ -2,6 +2,7 @@
 
 namespace Barryvdh\Cors\Stack;
 
+use Barryvdh\Cors\Util\OriginMatcher;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -165,7 +166,12 @@ class CorsService
         }
         $origin = $request->headers->get('Origin');
 
-        return in_array($origin, $this->options['allowedOrigins']);
+        foreach ($this->options['allowedOrigins'] as $allowedOrign) {
+            if (OriginMatcher::matches($allowedOrign, $origin)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private function checkMethod(Request $request) {

--- a/src/Util/OriginMatcher.php
+++ b/src/Util/OriginMatcher.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Barryvdh\Cors\Util;
+
+class OriginMatcher
+{
+
+    public static function matches($pattern, $origin)
+    {
+        if ($pattern === $origin) {
+            return true;
+        }
+        $scheme = parse_url($origin, PHP_URL_SCHEME);
+        $host   = parse_url($origin, PHP_URL_HOST);
+        $port   = parse_url($origin, PHP_URL_PORT);
+
+        $schemePattern = static::parseOriginPattern($pattern, PHP_URL_SCHEME);
+        $hostPattern   = static::parseOriginPattern($pattern, PHP_URL_HOST);
+        $portPattern   = static::parseOriginPattern($pattern, PHP_URL_PORT);
+
+        $schemeMatches = static::schemeMatches($schemePattern, $scheme);
+        $hostMatches   = static::hostMatches($hostPattern, $host);
+        $portMatches   = static::portMatches($portPattern, $port);
+        return $schemeMatches && $hostMatches && $portMatches;
+    }
+
+    public static function schemeMatches($pattern, $scheme)
+    {
+        return is_null($pattern) || $pattern === $scheme;
+    }
+
+    public static function hostMatches($pattern, $host)
+    {
+        $patternComponents = array_reverse(explode('.', $pattern));
+        $hostComponents  = array_reverse(explode('.', $host));
+        foreach ($patternComponents as $index => $patternComponent) {
+            if ($patternComponent === '*') {
+                return true;
+            }
+            if (!isset($hostComponents[$index])) {
+                return false;
+            }
+            if ($hostComponents[$index] !== $patternComponent) {
+                return false;
+            }
+        }
+        return count($patternComponents) === count($hostComponents);
+    }
+
+    public static function portMatches($pattern, $port)
+    {
+        return is_null($pattern) || $pattern === $port;
+    }
+
+    public static function parseOriginPattern($originPattern, $component = -1)
+    {
+        $matched = preg_match(
+            '!\A
+                (?: (?P<scheme> https? ):// )?
+                (?P<host> (?:\*|[\w-]+)(?:\.[\w-]+)* )
+                (?: :(?P<port> \d+ ) )?
+            \z!x',
+            $originPattern,
+            $captured
+        );
+        if (!$matched) {
+            throw new \Exception("Invalid origin pattern ${originPattern}");
+        }
+        $components = [
+            'scheme' => $captured['scheme'] ?: null,
+            'host'   => $captured['host'],
+            'port'   => array_key_exists('port', $captured) ? (int) $captured['port'] : null,
+        ];
+        switch ($component) {
+            case -1:
+                return $components;
+            case PHP_URL_SCHEME:
+                return $components['scheme'];
+            case PHP_URL_HOST:
+                return $components['host'];
+            case PHP_URL_PORT:
+                return $components['port'];
+        }
+        throw new \Exception("Invalid component: ${component}");
+    }
+}

--- a/tests/Util/OriginMatcherTest.php
+++ b/tests/Util/OriginMatcherTest.php
@@ -1,0 +1,219 @@
+<?php
+
+use Barryvdh\Cors\Util\OriginMatcher;
+
+class OriginMatcherTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider parseOriginPatternDataProvider
+     */
+    public function testParseOriginPattern($origin, $result)
+    {
+        $this->assertSame(
+            $result,
+            OriginMatcher::parseOriginPattern($origin)
+        );
+        $this->assertSame(
+            $result['scheme'],
+            OriginMatcher::parseOriginPattern($origin, PHP_URL_SCHEME)
+        );
+        $this->assertSame(
+            $result['host'],
+            OriginMatcher::parseOriginPattern($origin, PHP_URL_HOST)
+        );
+        $this->assertSame(
+            $result['port'],
+            OriginMatcher::parseOriginPattern($origin, PHP_URL_PORT)
+        );
+    }
+
+    public function parseOriginPatternDataProvider()
+    {
+        return [
+            [
+                'google.com',
+                ['scheme' => null, 'host' => 'google.com', 'port' => null],
+            ],
+            [
+                '*.google.com',
+                ['scheme' => null, 'host' => '*.google.com', 'port' => null],
+            ],
+            [
+                'http://google.com',
+                ['scheme' => 'http', 'host' => 'google.com', 'port' => null],
+            ],
+            [
+                'http://*.google.com',
+                ['scheme' => 'http', 'host' => '*.google.com', 'port' => null],
+            ],
+            [
+                'google.com:8080',
+                ['scheme' => null, 'host' => 'google.com', 'port' => 8080],
+            ],
+            [
+                '*.google.com:8080',
+                ['scheme' => null, 'host' => '*.google.com', 'port' => 8080],
+            ],
+            [
+                'https://google.com:8080',
+                ['scheme' => 'https', 'host' => 'google.com', 'port' => 8080],
+            ],
+            [
+                'https://*.google.com:8080',
+                ['scheme' => 'https', 'host' => '*.google.com', 'port' => 8080],
+            ],
+            [
+                'https://*.g-o_o1gLe.com:8080',
+                ['scheme' => 'https', 'host' => '*.g-o_o1gLe.com', 'port' => 8080],
+            ],
+            [
+                '*',
+                ['scheme' => null, 'host' => '*', 'port' => null],
+            ],
+            [
+                'https://*',
+                ['scheme' => 'https', 'host' => '*', 'port' => null],
+            ],
+            [
+                '*:8000',
+                ['scheme' => null, 'host' => '*', 'port' => 8000],
+            ],
+            [
+                '192.168.0.1',
+                ['scheme' => null, 'host' => '192.168.0.1', 'port' => null],
+            ],
+            [
+                'localhost',
+                ['scheme' => null, 'host' => 'localhost', 'port' => null],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider parseOriginPatternInvalidPatternDataProvider
+     * @expectedException Exception
+     */
+    public function testParseOriginPatternInvalidPattern($pattern)
+    {
+        OriginMatcher::parseOriginPattern($pattern);
+    }
+
+    public function parseOriginPatternInvalidPatternDataProvider()
+    {
+        return [
+            ['foo.*'],
+            ['foo..bar'],
+            ['ftp://google.com'],
+            ['http:/google.com'],
+            ['//google.com'],
+            ['google:com'],
+        ];
+    }
+
+    /**
+     * @dataProvider parseOriginPatternInvalidComponentDataProvider
+     * @expectedException Exception
+     */
+    public function testParseOriginPatternInvalidComponent($pattern, $component)
+    {
+        OriginMatcher::parseOriginPattern($pattern, $component);
+    }
+
+    public function parseOriginPatternInvalidComponentDataProvider()
+    {
+        return [
+            ['google.com', PHP_URL_USER],
+            ['google.com', PHP_URL_PASS],
+            ['google.com', PHP_URL_QUERY],
+            ['google.com', PHP_URL_FRAGMENT],
+        ];
+    }
+
+    /**
+     * @dataProvider schemeMatchesDataProvider
+     */
+    public function testSchemeMatches($pattern, $scheme, $matches)
+    {
+        $this->assertSame(
+            $matches,
+            OriginMatcher::schemeMatches($pattern, $scheme)
+        );
+    }
+
+    public function schemeMatchesDataProvider()
+    {
+        return [
+            ['http', 'http' , true ],
+            [null  , 'http' , true ],
+            ['http', 'https', false],
+            ['ftp' , 'http' , false],
+        ];
+    }
+
+    /**
+     * @dataProvider hostMatchesDataProvider
+     */
+    public function testHostMatches($pattern, $host, $matches)
+    {
+        $this->assertSame(
+            $matches,
+            OriginMatcher::hostMatches($pattern, $host)
+        );
+    }
+
+    public function hostMatchesDataProvider()
+    {
+        return [
+            ['google.com'     , 'google.com'     , true ],
+            ['*.google.com'   , 'maps.google.com', true ],
+            ['maps.google.com', 'google.com'     , false],
+            ['maps.google.com', '*.google.com'   , false],
+            ['google.com'     , 'maps.google.com', false],
+            ['google.com'     , null             , false],
+        ];
+    }
+
+    /**
+     * @dataProvider portMatchesDataProvider
+     */
+    public function testPortMatches($pattern, $port, $matches)
+    {
+        $this->assertSame(
+            $matches,
+            OriginMatcher::portMatches($pattern,$port)
+        );
+    }
+
+    public function portMatchesDataProvider()
+    {
+        return [
+            [8080, 8080, true],
+            [null, 8080, true],
+            [8080, 8090, false],
+            [8000, null, false],
+        ];
+    }
+
+    /**
+     * @dataProvider matchesDataProvider
+     */
+    public function testMatches($pattern, $origin, $matches)
+    {
+        $this->assertSame(
+            $matches,
+            OriginMatcher::matches($pattern, $origin)
+        );
+    }
+
+    public function matchesDataProvider()
+    {
+        return [
+            ['google.com'            , 'google.com'                 , true ],
+            ['http://google.com'     , 'http://google.com'          , true ],
+            ['http://google.com:8000', 'http://google.com:8000'     , true ],
+            ['*.google.com'          , 'http://google.com:8000'     , true ],
+            ['*.google.com'          , 'http://maps.google.com:8000', true ],
+            ['http://*.google.com'   , 'https://maps.google.com'    , false],
+        ];
+    }
+}


### PR DESCRIPTION
# What this change does?

Origin url can vary in development and staging phases, and huge list would be required for complete matching, so I made `allowedOrigins` list accepts wildcards and port ranges.

# Examples

- `http://*.google.com` allows http://maps.google.com, http://photos.google.com, etc.
- `google.com` allows both http://google.com and https://google.com.
- `http://google.com:8000-9000` allows any port number between 8000 and 9000.
- And combinations work just as expected.

# Notes

For scheme part, omitting scheme implies "any", different from other parts where `*` means "any".
I made this spec because `*://google.com` looks strange.
If you don't agree, I will change so that `*` points "any".

`*.google.com` accepts subdomains of google.com and ALSO accepts google.com itself, like cookies where `.google.com` accepts both.

There already be a similar [PR](https://github.com/barryvdh/laravel-cors/pull/107) that accepts regex in `allowedOrigins`.
But I think regex lowers maintenability of the list.
With my implementation, `allowedOrigins` is kept cleaner and can have backward compatibility.