### PR TITLE
Identify https in load balance environment with ssl termination

### DIFF
--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -163,7 +163,13 @@ class CorsService
 
     private function isSameHost(Request $request)
     {
-        return $request->headers->get('Origin') === $request->getSchemeAndHttpHost();
+        $scheme = $request->getScheme();
+
+        if (strtolower($request->server->get('HTTP_X_FORWARDED_PROTO')) === 'https') {
+            $scheme = 'https';
+        }
+
+        return $request->headers->get('Origin') === ($scheme . '://' . $request->getHttpHost());
     }
 
     private function checkOrigin(Request $request)


### PR DESCRIPTION
In a Load balance environment with SSL Termination. The call to `isSameHost()` always returned true even when the request was made from the non secure origin (eg http://sample.com - to - https://sample.com/api) ... causing the cors service not to handle preflight requests in this scenario

This pull request modifies this behavior to also check for the `HTTP_X_FORWARDED_PROTO` header sent by the load balancer... 

