### PR TITLE
Fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,10 +104,10 @@ On Laravel Lumen, load your configuration file manually in `bootstrap/app.php`:
 $app->configure('cors');
 ```
 
-And register the ServiceProvider:
+And register the LumenServiceProvider:
 
 ```php
-$app->register(Barryvdh\Cors\ServiceProvider::class);
+$app->register(Barryvdh\Cors\LumenServiceProvider::class);
 ```
 
 ## Global usage for Lumen


### PR DESCRIPTION
When you try to register ServiceProvider in Lumen project it returns:

```
[Illuminate\Contracts\Container\BindingResolutionException]
Target [Illuminate\Contracts\Http\Kernel] is not instantiable.
```