### PR TITLE
Update illuminate components for 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.3.x|5.4.x",
+        "illuminate/support": "5.3.x|5.4.x|5.5.x",
         "symfony/http-foundation": "~3.1",
         "symfony/http-kernel": "~3.1"
     },


### PR DESCRIPTION
Since I've seen you had pushed support for package auto-discovery, I assumed that it was ok to install in 5.5, but it seems that the illuminate components where still stuck to 5.4 and earlier. So it's just an update to add the 5.5 version also.

**NOTE**: I'm not sure if the packages is dependent on specific 5.4/5.3 illuminate components. If it is, maybe it's not a good idea to merge just yet. Although, on a test install of a 5.5-dev, it seems all ok!