### PR TITLE
Fix middleware matching (bring back gatherRouteMiddleware)

### DIFF
--- a/src/HandlePreflight.php
+++ b/src/HandlePreflight.php
@@ -72,7 +72,17 @@ class HandlePreflight
      */
     protected function hasMatchingCorsRoute($route)
     {
-        return in_array(HandleCors::class, $route->middleware());
+        /** @var Router $router */
+        $router = app(Router::class);
+
+        // change of method name in laravel 5.3
+        if (method_exists($router, 'gatherRouteMiddleware')) {
+            $middleware = $router->gatherRouteMiddleware($route);
+        } else {
+            $middleware = $router->gatherRouteMiddlewares($route);
+        }
+
+        return in_array(HandleCors::class, $middleware);
     }
 
     /**


### PR DESCRIPTION
Some of the changes introduced in 8cc5f947a853aed9797cfee5429ba8aca1034471 break middleware matching when CORS middleware is added to a group or is aliased (it only works if added as a global middleware). This results in all preflight request being rejected with a 403. 

`$route->middleware()` returns the actual strings that were used for middleware registration before they are resolved from groups or aliases. This PR reverts back to calling the router's `gatherRouteMiddleware` method that fully resolves middleware class names.

(This has surfaced now as we've started upgrading to Laravel 5.5 and switched to the "dev-master" version of the library)