### PR TITLE
 Fix error 405 Method Not Allowed for Lumen

### DIFF
--- a/src/HandlePreflight.php
+++ b/src/HandlePreflight.php
@@ -32,6 +32,6 @@ class HandlePreflight
             return $this->cors->addPreflightRequestHeaders($response, $request);
         }
 
-        return $response = $next($request);
+        return $next($request);
     }
 }

--- a/src/HandlePreflight.php
+++ b/src/HandlePreflight.php
@@ -27,12 +27,11 @@ class HandlePreflight
      */
     public function handle($request, Closure $next)
     {
-        $response = $next($request);
-
         if ($this->cors->isPreflightRequest($request)) {
+            $response = new Response();
             return $this->cors->addPreflightRequestHeaders($response, $request);
         }
 
-        return $response;
+        return $response = $next($request);
     }
 }


### PR DESCRIPTION
Process "$next($request)" before responding preflight causes an error on Lumen