### PR TITLE
Fix error 405 Method Not Allowed for Lumen

### DIFF
--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -69,6 +69,11 @@ class CorsService
             return $response;
         }
 
+        if ($response->getStatusCode() == 405) {
+            $response->setContent('');
+            $response->setStatusCode(200);
+        }
+
         $allowOrigin = $this->options['allowedOrigins'] === true && !$this->options['supportsCredentials']
             ? '*'
             : $request->headers->get('Origin');


### PR DESCRIPTION
Keep checking 404 before responding preflight.
But it's still throwing MethodNotAllowedHttpException.
At least, it keep the package working.