### PR TITLE
Add Laravel v5.7 to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.3.x|5.4.x|5.5.x|5.6.x",
+        "illuminate/support": "5.3.x|5.4.x|5.5.x|5.6.x|5.7.x",
         "symfony/http-foundation": "^3.1|^4",
         "symfony/http-kernel": "^3.1|^4",
         "asm89/stack-cors": "^1.2"


### PR DESCRIPTION
I had a brief look through the change-list of 5.7, can not find any reason why it would not work.