### PR TITLE
Bumped dependency to Laravel 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
       env: laravel=5.3.x
     - php: 7.0
       env: laravel=5.4.x
+    - php: 7.1
+      env: laravel=5.6.x
+    - php: 7.1
+      env: laravel=5.7.x
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.3.x|5.4.x|5.5.x|5.6.x",
+        "illuminate/support": "5.3.x|5.4.x|5.5.x|5.6.x|5.7.x",
         "symfony/http-foundation": "^3.1|^4",
         "symfony/http-kernel": "^3.1|^4",
         "asm89/stack-cors": "^1.2"
@@ -37,7 +37,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.2",
+        "phpunit/phpunit": "^4.8|^5.2|^7.0",
         "orchestra/testbench": "3.x",
         "squizlabs/php_codesniffer": "^2.3"
     },


### PR DESCRIPTION
I've made laravel-cors composer and TravisCI files compatible with Laravel 5.7 as well as other maintaining support for the existing versions. Plus, TravisCI will now run Laravel 5.6 and Laravel 5.7 tests against PHP 7.1 as per Laravel's dependencies.