### PR TITLE
Updated dependencies constraints and Updated Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,68 @@
 language: php
 
-php:
-  - 7.1
-  - 7.2
-
-env:
-  global:
-    - setup=stable
-    - laravel=5.x
-    - testbench=3.x
-
 matrix:
   include:
+    - php: 7.0
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.0
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-stable'
     - php: 7.1
-      env: setup=lowest
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.1
-      env:
-        - laravel=5.6.x
-        - testbench=3.6.x
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-stable'
     - php: 7.1
-      env:
-        - laravel=5.7.x
-        - testbench=3.7.x
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.1
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.1
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.1
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.1
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.1
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='6.*' TESTBENCH='4.*' COMPOSER_FLAGS='--prefer-stable'
+  fast_finish: true
 
 sudo: false
 
@@ -29,12 +70,14 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+before_script:
+    - phpenv config-rm xdebug.ini || true
+
+before_install:
+  - travis_retry composer require "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}" --no-interaction --no-update
+
 install:
-  - composer require illuminate/support:${laravel} --no-update
-  - composer require laravel/framework:${laravel} --no-update
-  - composer require orchestra/testbench:${testbench} --no-update
-  - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable; fi
-  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable; fi
+  - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction --no-suggest
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "require": {
         "php": ">=7",
         "illuminate/support": "^5.5|^6",
-        "symfony/http-foundation": "^3.1|^4",
-        "symfony/http-kernel": "^3.1|^4",
+        "symfony/http-foundation": "^3.3|^4",
+        "symfony/http-kernel": "^3.3|^4",
         "asm89/stack-cors": "^1.2"
     },
     "autoload": {
@@ -37,9 +37,9 @@
         }
     },
     "require-dev": {
-        "laravel/framework": "^5.5",
-        "phpunit/phpunit": "^4.8|^5.2|^7.0",
-        "orchestra/testbench": "3.3.x|3.4.x|3.5.x|3.6.x|3.7.x",
+        "laravel/framework": "^5.5|^6",
+        "phpunit/phpunit": "^6.0|^7.0|^8.0",
+        "orchestra/testbench": "^3.5|^4.0",
         "squizlabs/php_codesniffer": "^2.3"
     },
     "scripts": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,6 @@
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
 >
     <testsuites>

--- a/readme.md
+++ b/readme.md
@@ -134,16 +134,6 @@ $app->routeMiddleware([
     'cors' => \Barryvdh\Cors\HandleCors::class,
 ]);
 ```
-
-## Common problems and errors (Pre Laravel 5.3)
-In order for the package to work, the request has to be a valid CORS request and needs to include an "Origin" header.
-
-When an error occurs, the middleware isn't run completely. So when this happens, you won't see the actual result, but will get a CORS error instead.
-
-This could be a CSRF token error or just a simple problem.
-
-> **Note:** This should be working in Laravel 5.3+.
-
 ### Disabling CSRF protection for your API
 
 If possible, use a different route group with CSRF protection enabled. 

--- a/tests/GlobalMiddlewareTest.php
+++ b/tests/GlobalMiddlewareTest.php
@@ -134,10 +134,6 @@ class GlobalMiddlewareTest extends TestCase
 
     public function testError()
     {
-        if ($this->checkVersion('5.3', '<')) {
-            $this->markTestSkipped('Catching exceptions is not possible on Laravel 5.1');
-        }
-
         $crawler = $this->call('POST', 'web/error', [], [], [], [
             'HTTP_ORIGIN' => 'localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
@@ -149,10 +145,6 @@ class GlobalMiddlewareTest extends TestCase
 
     public function testValidationException()
     {
-        if ($this->checkVersion('5.3', '<')) {
-            $this->markTestSkipped('Catching exceptions is not possible on Laravel 5.1');
-        }
-
         $crawler = $this->call('POST', 'web/validation', [], [], [], [
             'HTTP_ORIGIN' => 'localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',

--- a/tests/GroupMiddlewareTest.php
+++ b/tests/GroupMiddlewareTest.php
@@ -95,10 +95,6 @@ class GroupMiddlewareTest extends TestCase
 
     public function testError()
     {
-        if ($this->checkVersion('5.3', '<')) {
-            $this->markTestSkipped('Catching exceptions is not possible on Laravel 5.1');
-        }
-
         $crawler = $this->call('POST', 'api/error', [], [], [], [
             'HTTP_ORIGIN' => 'localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
@@ -110,10 +106,6 @@ class GroupMiddlewareTest extends TestCase
 
     public function testValidationException()
     {
-        if ($this->checkVersion('5.3', '<')) {
-            $this->markTestSkipped('Catching exceptions is not possible on Laravel 5.1');
-        }
-
         $crawler = $this->call('POST', 'api/validation', [], [], [], [
             'HTTP_ORIGIN' => 'localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -119,9 +119,4 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             ]);
         });
     }
-
-    protected function checkVersion($version, $operator = ">=")
-    {
-        return version_compare($this->app->version(), $version, $operator);
-    }
 }


### PR DESCRIPTION
This **PR** will:
​
- Update dependencies constraints
    - Update **laravel/framework** to support Laravel 6 in `require-dev`
    - remove **phpunit/phpunit**: "**^4.8|^5.2**" ( Compatible only PHP <= 5.6 )
    - Add **phpunit/phpunit**: "**^6.0|^8.0**"
    - Update **symfony/http-foundation** and **symfony/http-kernel** minimal version to **^3.3** ( Required by Laravel 5.5 )
    - Update **orchestra/testbench** - version compatibility:

Laravel | Testbench
-- | --
5.5.x | 3.5.x
5.6.x | 3.6.x
5.7.x | 3.7.x
5.8.x | 3.8.x
6.x | 4.x

- Run tests against **all stable versions** of **PHP/Laravel** supported by the package
    - Update .travis.yml
- Remove legacy phpunit flag
    - `syntaxCheck="true"`
- Remove old references from Laravel <5.3